### PR TITLE
Enable deleting cloud transactions

### DIFF
--- a/style.css
+++ b/style.css
@@ -1111,6 +1111,20 @@ body {
   color: var(--color-error);
 }
 
+.transaction-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.delete-btn {
+  background: none;
+  border: none;
+  color: var(--color-error);
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
 /* Sidebar */
 .sidebar {
   display: flex;


### PR DESCRIPTION
## Summary
- add `datosNube` sample data and manage it through `datosUsuariosNube` state
- allow removing transactions in "Nube" mode
- update cloud mode message
- style delete button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883a5fc9124833292720480c91c327d